### PR TITLE
Bugfix: Chart gets rerendered after adding Graph

### DIFF
--- a/client/src/components/Browse/FetchModal.js
+++ b/client/src/components/Browse/FetchModal.js
@@ -161,7 +161,6 @@ const FetchModal = () => {
 	const addGraph = (reset, checkedData, config, type) => {
 		const { datasets, labels, colorId, options } = checkedData;
 		const checkString = `${type}-${host}-${date}-${fetchHour}`;
-		config.id = 100000 * Math.random();
 		if (reset) {
 			config = {
 				...config,


### PR DESCRIPTION
The rerender gets triggered, because the key prop of the ChartWrapper Component is set to the chart.id property, which gets updated when you add a Graph to the Chart.